### PR TITLE
Use 12: rather than 00: for midnight

### DIFF
--- a/lib/ExpressionDescriptor.cs
+++ b/lib/ExpressionDescriptor.cs
@@ -696,6 +696,10 @@ namespace CronExpressionDescriptor
                 {
                     hour -= 12;
                 }
+                if (hour == 0)
+                {
+                    hour = 12;
+                }
             }
 
             string minute = Convert.ToInt32(minuteExpression).ToString();

--- a/test/TestFormats.en.cs
+++ b/test/TestFormats.en.cs
@@ -187,7 +187,7 @@ namespace CronExpressionDescriptor.Test
         [Fact]
         public void TestLastDayOffset()
         {
-            Assert.Equal("At 00:00 AM, 5 days before the last day of the month", GetDescription("0 0 0 L-5 * ?"));
+            Assert.Equal("At 12:00 AM, 5 days before the last day of the month", GetDescription("0 0 0 L-5 * ?"));
         }
 
         [Fact]
@@ -427,7 +427,7 @@ namespace CronExpressionDescriptor.Test
         public void TestDayOfWeekWithDayOfMonth()
         {
             // GitHub Issue #46: https://github.com/bradyholt/cron-expression-descriptor/issues/46
-            Assert.Equal("At 00:00 AM, on day 1, 2, and 3 of the month, only on Wednesday and Friday", GetDescription("0 0 0 1,2,3 * WED,FRI"));
+            Assert.Equal("At 12:00 AM, on day 1, 2, and 3 of the month, only on Wednesday and Friday", GetDescription("0 0 0 1,2,3 * WED,FRI"));
         }
 
         [Fact]


### PR DESCRIPTION
00:00 AM is not a valid time so we will now use 12:?? AM for midnight time description when not using 24 hour format.

Fixes #74 
