### PR TITLE
Fixed locale-specific Regex.Replace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,4 +6,4 @@ end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 indent_style = space
-indent_size = 2
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ test/bin/
 test/obj/
 demo/bin/
 demo/obj/
+.vs
+.idea

--- a/lib/ExpressionParser.cs
+++ b/lib/ExpressionParser.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Globalization;
 
@@ -170,7 +168,7 @@ namespace CronExpressionDescriptor
             {
                 DayOfWeek currentDay = (DayOfWeek)i;
                 string currentDayOfWeekDescription = currentDay.ToString().Substring(0, 3).ToUpperInvariant();
-                expressionParts[5] = Regex.Replace(expressionParts[5], currentDayOfWeekDescription, i.ToString(), RegexOptions.IgnoreCase);
+                expressionParts[5] = Regex.Replace(expressionParts[5], currentDayOfWeekDescription, i.ToString(), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
             }
 
@@ -179,7 +177,7 @@ namespace CronExpressionDescriptor
             {
                 DateTime currentMonth = new DateTime(DateTime.Now.Year, i, 1);
                 string currentMonthDescription = currentMonth.ToString("MMM", m_en_culture).ToUpperInvariant();
-                expressionParts[4] = Regex.Replace(expressionParts[4], currentMonthDescription, i.ToString(), RegexOptions.IgnoreCase);
+                expressionParts[4] = Regex.Replace(expressionParts[4], currentMonthDescription, i.ToString(), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
             }
 
             // Convert 0 second to (empty)

--- a/test/TestParsing.cs
+++ b/test/TestParsing.cs
@@ -1,0 +1,7 @@
+namespace CronExpressionDescriptor.Test
+{
+    public class TestParsing
+    {
+
+    }
+}

--- a/test/TestParsing.cs
+++ b/test/TestParsing.cs
@@ -1,7 +1,21 @@
+using Xunit;
+
 namespace CronExpressionDescriptor.Test
 {
     public class TestParsing
     {
+        [Fact]
+        public void TestWeekDayAndMonthParsing()
+        {
+            var expression = "0 59 23 31 dEc frI *";
+            var options = new Options
+            {
+                Locale = "en"
+            };
 
+            var res = ExpressionDescriptor.GetDescription(expression, options);
+            
+            Assert.Equal("At 11:59 PM, on day 31 of the month, only on Friday, only in December", res);
+        }
     }
 }

--- a/test/TestParsing.cs
+++ b/test/TestParsing.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Threading;
 using Xunit;
 
 namespace CronExpressionDescriptor.Test
@@ -7,15 +9,30 @@ namespace CronExpressionDescriptor.Test
         [Fact]
         public void TestWeekDayAndMonthParsing()
         {
-            var expression = "0 59 23 31 dEc frI *";
+            const string expression = "0 59 23 31 DEC Fri *";
+
             var options = new Options
             {
                 Locale = "en"
             };
 
-            var res = ExpressionDescriptor.GetDescription(expression, options);
-            
-            Assert.Equal("At 11:59 PM, on day 31 of the month, only on Friday, only in December", res);
+            var oldCulture = Thread.CurrentThread.CurrentCulture;
+
+            try
+            {
+                foreach (var culture in CultureInfo.GetCultures(CultureTypes.AllCultures))
+                {
+                    Thread.CurrentThread.CurrentCulture = culture;
+
+                    var res = ExpressionDescriptor.GetDescription(expression, options);
+
+                    Assert.Equal("At 11:59 PM, on day 31 of the month, only on Friday, only in December", res);
+                }
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = oldCulture;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixed `ExpressionParser.NormalizeExpression` to use locale-independent `Regex.Replace`. Previously it did not work under certain cultures (like Turkish `tr`).

Also
* Fix `.editorconfig`: all existing files use 4-space indent
* Update `.gitignore` to ignore Visual Studio and Rider stuff