### PR TITLE
every-nth-week-support: Adding Every Nth Week descriptors

### DIFF
--- a/lib/ExpressionParser.cs
+++ b/lib/ExpressionParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Globalization;
@@ -104,6 +104,8 @@ namespace CronExpressionDescriptor
     /// <param name="expressionParts">A 7 part string array, one part for each component of the cron expression</param>
     private void NormalizeExpression(string[] expressionParts)
     {
+      bool skipWeekDayNormalization = Regex.IsMatch(expressionParts[5], @"[a-zA-Z]");
+
       // Convert ? to * only for DOM and DOW
       expressionParts[3] = expressionParts[3].Replace("?", "*");
       expressionParts[5] = expressionParts[5].Replace("?", "*");
@@ -181,14 +183,7 @@ namespace CronExpressionDescriptor
         expressionParts[3] = "*";
       }
 
-      // Convert SUN-SAT format to 0-6 format
-      for (int i = 0; i <= 6; i++)
-      {
-        DayOfWeek currentDay = (DayOfWeek)i;
-        string currentDayOfWeekDescription = currentDay.ToString().Substring(0, 3).ToUpperInvariant();
-        expressionParts[5] = Regex.Replace(expressionParts[5], currentDayOfWeekDescription, i.ToString(), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
-      }
 
       // Convert JAN-DEC format to 1-12 format
       for (int i = 1; i <= 12; i++)
@@ -239,7 +234,11 @@ namespace CronExpressionDescriptor
           switch (i)
           {
             case 4: stepRangeThrough = "12"; break;
-            case 5: stepRangeThrough = "6"; break;
+            case 5:
+                if (skipWeekDayNormalization)
+                    stepRangeThrough = null;
+                else stepRangeThrough = "6";
+                break;
             case 6: stepRangeThrough = "9999"; break;
             default: stepRangeThrough = null; break;
           }

--- a/lib/Resources.resx
+++ b/lib/Resources.resx
@@ -307,4 +307,8 @@
   <data name="ComaOnlyInYearX0" xml:space="preserve">
     <value>, only in {0}</value>
   </data>
+  <data name="ComaEveryX0Weeks" xml:space="preserve">
+    <value>, every {0} weeks</value>
+    <comment>ComaEveryX0Weeks description</comment>
+  </data>
 </root>

--- a/test/TestFormats.en.cs
+++ b/test/TestFormats.en.cs
@@ -1,4 +1,4 @@
-﻿using Xunit;
+using Xunit;
 using Assert = CronExpressionDescriptor.Test.Support.AssertExtensions;
 
 namespace CronExpressionDescriptor.Test
@@ -528,8 +528,24 @@ namespace CronExpressionDescriptor.Test
     }
 
     [Fact]
-    public void Sunday7(){
+    public void Sunday7()
+    {
         Assert.Equal("At 09:00 AM, only on Sunday", GetDescription("0 0 9 ? * 7"));
+    }
+    [Fact]
+    public void TestEvery2WeeksOnFriday()
+    {
+        Assert.Equal("At 12:00 PM, every 2 weeks, only on Friday", GetDescription("0 0 12 ? * FRI/2"));
+    }
+    [Fact]
+    public void TestEvery3WeeksWedThroughFri()
+    {
+        Assert.Equal("At 12:00 PM, every 3 weeks, Wednesday through Friday", GetDescription("0 0 12 ? * WED-FRI/3"));
+    }
+    [Fact]
+    public void TestEvery4WeeksTueAndFri()
+    {
+        Assert.Equal("At 12:00 PM, every 4 weeks, only on Tuesday and Friday", GetDescription("0 0 12 ? * TUE,FRI/4"));
     }
   }
 }


### PR DESCRIPTION
Support for Every Nth Week recurrence.

Currently Cron expressions do not have support for recurrence patterns such as Every 2 weeks on Wednesday. This feature adds such support.

For example:
Cron Expression: "0 0 12 ? * FRI/2", Description: "At 12:00 PM, every 2 weeks, only on Friday"
Cron Expression: "0 0 12 ? * WED-FRI/3", Description: "At 12:00 PM, every 3 weeks, Wednesday through Friday"
Cron Expression: "0 0 12 ? * TUE,FRI/4", Description: "At 12:00 PM, every 4 weeks, only on Tuesday and Friday"

I also have added a [pull request](https://github.com/quartznet/quartznet/pull/790) for Quartz.NET to support the same "Every Nth Week" recurrence pattern.