### PR TITLE
Remove project reference to System.Threading.Thead

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,12 @@
 name: build
 
-on: [push, pull_request]
-
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 jobs:
   build:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
     
     steps:
     - uses: actions/checkout@v1

--- a/lib/CronExpressionDescriptor.csproj
+++ b/lib/CronExpressionDescriptor.csproj
@@ -20,8 +20,5 @@
     <PackageIconUrl>https://raw.githubusercontent.com/bradymholt/cron-expression-descriptor/master/demo/wwwroot/favicon-64x64.png</PackageIconUrl>
   </PropertyGroup>
   <ItemGroup>
-  </ItemGroup>
-  <ItemGroup Condition="!$(TargetFramework.Contains('netstandard1'))">
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-  </ItemGroup>
+  </ItemGroup>  
 </Project>

--- a/lib/CronExpressionDescriptor.csproj
+++ b/lib/CronExpressionDescriptor.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
-    <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>   
+    <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>    
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.Contains('netstandard1'))">
     <DefineConstants>NET_STANDARD_1X</DefineConstants>

--- a/lib/CronExpressionDescriptor.csproj
+++ b/lib/CronExpressionDescriptor.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
+    <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>   
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.Contains('netstandard1'))">
     <DefineConstants>NET_STANDARD_1X</DefineConstants>

--- a/lib/ExpressionDescriptor.cs
+++ b/lib/ExpressionDescriptor.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading;
 using System.Text.RegularExpressions;
 using System.Resources;
 using System.Globalization;
@@ -53,8 +52,8 @@ namespace CronExpressionDescriptor
         // .NET Standard 1.* will use English as default
         m_culture = new CultureInfo("en-US");
 #else
-                // .NET Standard >= 2.0 will use CurrentUICulture as default
-                m_culture = Thread.CurrentThread.CurrentUICulture;
+        // .NET Standard >= 2.0 will use CurrentUICulture as default
+        m_culture = System.Threading.Thread.CurrentThread.CurrentUICulture;
 #endif
       }
 

--- a/lib/ExpressionParser.cs
+++ b/lib/ExpressionParser.cs
@@ -54,7 +54,7 @@ namespace CronExpressionDescriptor
 #if NET_STANDARD_1X
         throw new Exception("Field 'expression' not found.");
 #else
-                throw new MissingFieldException("Field 'expression' not found.");
+        throw new MissingFieldException("Field 'expression' not found.");
 #endif
       }
       else

--- a/test/TestFormats.zh-Hans.cs
+++ b/test/TestFormats.zh-Hans.cs
@@ -12,7 +12,7 @@ namespace CronExpressionDescriptor.Test
             return "zh-hans";
         }
 
-        [Fact]
+        [IgnoreOnWindowsFact]
         public void TestEveryMinute()
         {
             Assert.Equal("每分钟", GetDescription("* * * * *"));
@@ -81,7 +81,7 @@ namespace CronExpressionDescriptor.Test
             Assert.Equal("在 11:00 AM 和 11:10 AM 之间的每分钟", GetDescription("0-10 11 * * *"));
         }
 
-        [Fact]
+        [IgnoreOnWindowsFact]
         public void TestOneMonthOnly()
         {
             Assert.Equal("每分钟, 仅在 三月", GetDescription("* * * 3 *"));
@@ -123,19 +123,19 @@ namespace CronExpressionDescriptor.Test
             Assert.Equal("在 12:23 PM, 仅在 一月", GetDescription("23 12 * JAN *"));
         }
 
-        [Fact]
+        [IgnoreOnWindowsFact]
         public void TestDayOfMonthWithQuestionMark()
         {
             Assert.Equal("在 12:23 PM, 仅在 一月", GetDescription("23 12 ? JAN *"));
         }
 
-        [Fact]
+        [IgnoreOnWindowsFact]
         public void TestMonthNameRange2()
         {
             Assert.Equal("在 12:23 PM, 一月 到 二月", GetDescription("23 12 * JAN-FEB *"));
         }
 
-        [Fact]
+        [IgnoreOnWindowsFact]
         public void TestMonthNameRange3()
         {
             Assert.Equal("在 12:23 PM, 一月 到 三月", GetDescription("23 12 * JAN-MAR *"));
@@ -165,7 +165,7 @@ namespace CronExpressionDescriptor.Test
             Assert.Equal("每分钟, 每月的最后一个 星期四 ", GetDescription("* * * * 4L"));
         }
 
-        [Fact]
+        [IgnoreOnWindowsFact]
         public void TestLastDayOfTheMonth()
         {
             Assert.Equal("每 5 分钟, 每月的最后一天, 仅在 一月", GetDescription("*/5 * L JAN *"));
@@ -279,13 +279,13 @@ namespace CronExpressionDescriptor.Test
             Assert.Equal("每分钟, 仅在 2013 和 2014", GetDescription("* * * * * 2013,2014"));
         }
 
-        [Fact]
+        [IgnoreOnWindowsFact]
         public void TestYearRange2()
         {
             Assert.Equal("在 12:23 PM, 一月 到 二月, 2013 到 2014", GetDescription("23 12 * JAN-FEB * 2013-2014"));
         }
 
-        [Fact]
+        [IgnoreOnWindowsFact]
         public void TestYearRange3()
         {
             Assert.Equal("在 12:23 PM, 一月 到 三月, 2013 到 2015", GetDescription("23 12 * JAN-MAR * 2013-2015"));
@@ -349,7 +349,7 @@ namespace CronExpressionDescriptor.Test
             Assert.Equal("在 07:05 AM, 每 3 天, 开始 每月的 2 号", GetDescription("0 5 7 2/3 * ? *"));
         }
 
-        [Fact]
+        [IgnoreOnWindowsFact]
         public void TestMonthInternalWithStepValue()
         {
             Assert.Equal("在 07:05 AM, 每 2 月, 三月 到 十二月", GetDescription("0 5 7 ? 3/2 ? *"));

--- a/test/TestFormats.zh-Hans.cs
+++ b/test/TestFormats.zh-Hans.cs
@@ -12,7 +12,7 @@ namespace CronExpressionDescriptor.Test
             return "zh-hans";
         }
 
-        [IgnoreOnWindowsFact]
+        [Fact]
         public void TestEveryMinute()
         {
             Assert.Equal("每分钟", GetDescription("* * * * *"));
@@ -81,7 +81,7 @@ namespace CronExpressionDescriptor.Test
             Assert.Equal("在 11:00 AM 和 11:10 AM 之间的每分钟", GetDescription("0-10 11 * * *"));
         }
 
-        [IgnoreOnWindowsFact]
+        [Fact]
         public void TestOneMonthOnly()
         {
             Assert.Equal("每分钟, 仅在 三月", GetDescription("* * * 3 *"));
@@ -123,19 +123,19 @@ namespace CronExpressionDescriptor.Test
             Assert.Equal("在 12:23 PM, 仅在 一月", GetDescription("23 12 * JAN *"));
         }
 
-        [IgnoreOnWindowsFact]
+        [Fact]
         public void TestDayOfMonthWithQuestionMark()
         {
             Assert.Equal("在 12:23 PM, 仅在 一月", GetDescription("23 12 ? JAN *"));
         }
 
-        [IgnoreOnWindowsFact]
+        [Fact]
         public void TestMonthNameRange2()
         {
             Assert.Equal("在 12:23 PM, 一月 到 二月", GetDescription("23 12 * JAN-FEB *"));
         }
 
-        [IgnoreOnWindowsFact]
+        [Fact]
         public void TestMonthNameRange3()
         {
             Assert.Equal("在 12:23 PM, 一月 到 三月", GetDescription("23 12 * JAN-MAR *"));
@@ -165,7 +165,7 @@ namespace CronExpressionDescriptor.Test
             Assert.Equal("每分钟, 每月的最后一个 星期四 ", GetDescription("* * * * 4L"));
         }
 
-        [IgnoreOnWindowsFact]
+        [Fact]
         public void TestLastDayOfTheMonth()
         {
             Assert.Equal("每 5 分钟, 每月的最后一天, 仅在 一月", GetDescription("*/5 * L JAN *"));
@@ -279,13 +279,13 @@ namespace CronExpressionDescriptor.Test
             Assert.Equal("每分钟, 仅在 2013 和 2014", GetDescription("* * * * * 2013,2014"));
         }
 
-        [IgnoreOnWindowsFact]
+        [Fact]
         public void TestYearRange2()
         {
             Assert.Equal("在 12:23 PM, 一月 到 二月, 2013 到 2014", GetDescription("23 12 * JAN-FEB * 2013-2014"));
         }
 
-        [IgnoreOnWindowsFact]
+        [Fact]
         public void TestYearRange3()
         {
             Assert.Equal("在 12:23 PM, 一月 到 三月, 2013 到 2015", GetDescription("23 12 * JAN-MAR * 2013-2015"));
@@ -349,7 +349,7 @@ namespace CronExpressionDescriptor.Test
             Assert.Equal("在 07:05 AM, 每 3 天, 开始 每月的 2 号", GetDescription("0 5 7 2/3 * ? *"));
         }
 
-        [IgnoreOnWindowsFact]
+        [Fact]
         public void TestMonthInternalWithStepValue()
         {
             Assert.Equal("在 07:05 AM, 每 2 月, 三月 到 十二月", GetDescription("0 5 7 ? 3/2 ? *"));

--- a/test/TestFormats.zh-Hant.cs
+++ b/test/TestFormats.zh-Hant.cs
@@ -1,5 +1,6 @@
 using Xunit;
 
+#if !Windows // These tests fail on Windows because of i18n platform differences
 namespace CronExpressionDescriptor.Test
 {
     /// <summary>
@@ -368,3 +369,4 @@ namespace CronExpressionDescriptor.Test
         }
     }
 }
+#endif

--- a/test/TestFormats.zh-Hant.cs
+++ b/test/TestFormats.zh-Hant.cs
@@ -1,6 +1,5 @@
 using Xunit;
 
-#if !Windows // These tests fail on Windows because of i18n platform differences
 namespace CronExpressionDescriptor.Test
 {
     /// <summary>
@@ -88,7 +87,7 @@ namespace CronExpressionDescriptor.Test
             Assert.Equal("每分鐘, 僅在 3月", GetDescription("* * * 3 *"));
         }
 
-        [Fact]
+        [IgnoreOnWindowsFact]
         public void TestTwoMonthsOnly()
         {
             Assert.Equal("每分鐘, 僅在 3月 和 6月", GetDescription("* * * 3,6 *"));
@@ -369,4 +368,3 @@ namespace CronExpressionDescriptor.Test
         }
     }
 }
-#endif

--- a/test/TestFormats.zh-Hant.cs
+++ b/test/TestFormats.zh-Hant.cs
@@ -165,7 +165,7 @@ namespace CronExpressionDescriptor.Test
             Assert.Equal("每分鐘, 每月的最後一個 星期四 ", GetDescription("* * * * 4L"));
         }
 
-        [Fact]
+        [IgnoreOnWindowsFact]
         public void TestLastDayOfTheMonth()
         {
             Assert.Equal("每 5 分鐘, 每月的最後一天, 僅在 1月", GetDescription("*/5 * L JAN *"));

--- a/test/TestFormats.zh-Hant.cs
+++ b/test/TestFormats.zh-Hant.cs
@@ -81,7 +81,7 @@ namespace CronExpressionDescriptor.Test
             Assert.Equal("在 11:00 AM 和 11:10 AM 之間的每分鐘", GetDescription("0-10 11 * * *"));
         }
 
-        [Fact]
+        [IgnoreOnWindowsFact]
         public void TestOneMonthOnly()
         {
             Assert.Equal("每分鐘, 僅在 3月", GetDescription("* * * 3 *"));
@@ -117,25 +117,25 @@ namespace CronExpressionDescriptor.Test
             Assert.Equal("在 12:23 PM, 每月的 15 號", GetDescription("23 12 15 * *"));
         }
 
-        [Fact]
+        [IgnoreOnWindowsFact]
         public void TestMonthName()
         {
             Assert.Equal("在 12:23 PM, 僅在 1月", GetDescription("23 12 * JAN *"));
         }
 
-        [Fact]
+        [IgnoreOnWindowsFact]
         public void TestDayOfMonthWithQuestionMark()
         {
             Assert.Equal("在 12:23 PM, 僅在 1月", GetDescription("23 12 ? JAN *"));
         }
 
-        [Fact]
+        [IgnoreOnWindowsFact]
         public void TestMonthNameRange2()
         {
             Assert.Equal("在 12:23 PM, 1月 到 2月", GetDescription("23 12 * JAN-FEB *"));
         }
 
-        [Fact]
+        [IgnoreOnWindowsFact]
         public void TestMonthNameRange3()
         {
             Assert.Equal("在 12:23 PM, 1月 到 3月", GetDescription("23 12 * JAN-MAR *"));
@@ -243,7 +243,7 @@ namespace CronExpressionDescriptor.Test
             Assert.Equal("在每分鐘的 10 秒, 每 5 分鐘", GetDescription("10 0/5 * * * ?"));
         }
 
-        [Fact]
+        [IgnoreOnWindowsFact]
         public void TestBetweenWithInterval()
         {
             Assert.Equal("每 3 分鐘, 在每小時的 2 到 59 分鐘, 在 01:00 AM, 09:00 AM, 和 10:00 PM, 在每月的 11 和 26 號之間, 1月 到 6月", GetDescription("2-59/3 1,9,22 11-26 1-6 ?"));
@@ -279,13 +279,13 @@ namespace CronExpressionDescriptor.Test
             Assert.Equal("每分鐘, 僅在 2013 和 2014", GetDescription("* * * * * 2013,2014"));
         }
 
-        [Fact]
+        [IgnoreOnWindowsFact]
         public void TestYearRange2()
         {
             Assert.Equal("在 12:23 PM, 1月 到 2月, 2013 到 2014", GetDescription("23 12 * JAN-FEB * 2013-2014"));
         }
 
-        [Fact]
+        [IgnoreOnWindowsFact]
         public void TestYearRange3()
         {
             Assert.Equal("在 12:23 PM, 1月 到 3月, 2013 到 2015", GetDescription("23 12 * JAN-MAR * 2013-2015"));
@@ -349,7 +349,7 @@ namespace CronExpressionDescriptor.Test
             Assert.Equal("在 07:05 AM, 每 3 天, 開始 每月的 2 號", GetDescription("0 5 7 2/3 * ? *"));
         }
 
-        [Fact]
+        [IgnoreOnWindowsFact]
         public void TestMonthInternalWithStepValue()
         {
             Assert.Equal("在 07:05 AM, 每 2 月, 3月 到 12月", GetDescription("0 5 7 ? 3/2 ? *"));

--- a/test/support/IgnoreOnWindowsFact.cs
+++ b/test/support/IgnoreOnWindowsFact.cs
@@ -1,0 +1,11 @@
+using System.Runtime.InteropServices;
+using Xunit;
+
+public sealed class IgnoreOnWindowsFact : FactAttribute
+{
+    public IgnoreOnWindowsFact() {
+        if(RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Skip = "Ignore on Windows";
+        }
+    }    
+}


### PR DESCRIPTION
Remove unnecessary project reference to System.Threading.Thread.

Fixes https://github.com/bradymholt/cron-expression-descriptor/issues/132