### PR TITLE
Update Go port

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ If you need an assembly that is [signed with a strong name](https://msdn.microso
  - Ruby - [https://github.com/alpinweis/cronex](https://github.com/alpinweis/cronex)
  - Python - [https://github.com/Salamek/cron-descriptor](https://github.com/Salamek/cron-descriptor)
  - JavaScript - [https://github.com/bradymholt/cRonstrue](https://github.com/bradymholt/cRonstrue)
+ - Go - [https://github.com/lnquy/cron](https://github.com/lnquy/cron)
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
Hi,
I've ported the code to Go at: https://github.com/lnquy/cron, so I would like to update the reference.
The API signature is almost the same as your cRonstrue repo, so you can take a look at the Godoc here if possible:
https://pkg.go.dev/github.com/lnquy/cron?tab=doc

Thanks,
Quy Le