### PR TITLE
At specific time translates to 'om' not 'op' in Dutch.

### DIFF
--- a/lib/Resources.nl.resx
+++ b/lib/Resources.nl.resx
@@ -129,7 +129,7 @@
     <comment>AnErrorOccurredWhenGeneratingTheExpressionD description</comment>
   </data>
   <data name="AtSpace" xml:space="preserve">
-    <value>Op </value>
+    <value>Om </value>
     <comment>At description</comment>
   </data>
   <data name="EveryMinuteBetweenX0AndX1" xml:space="preserve">
@@ -137,7 +137,7 @@
     <comment>EveryMinuteBetweenX0AndX1 description</comment>
   </data>
   <data name="At" xml:space="preserve">
-    <value>Op</value>
+    <value>Om</value>
     <comment>At description</comment>
   </data>
   <data name="SpaceAnd" xml:space="preserve">
@@ -157,7 +157,7 @@
     <comment>SecondsX0ThroughX1PastTheMinute description</comment>
   </data>
   <data name="AtX0SecondsPastTheMinute" xml:space="preserve">
-    <value>op {0} seconden na de minuut</value>
+    <value>om {0} seconden na de minuut</value>
     <comment>AtX0SecondsPastTheMinute description</comment>
   </data>
   <data name="EveryX0Minutes" xml:space="preserve">
@@ -169,7 +169,7 @@
     <comment>MinutesX0ThroughX1PastTheHour description</comment>
   </data>
   <data name="AtX0MinutesPastTheHour" xml:space="preserve">
-    <value>op {0} minuten na het uur</value>
+    <value>om {0} minuten na het uur</value>
     <comment>AtX0MinutesPastTheHour description</comment>
   </data>
   <data name="EveryX0Hours" xml:space="preserve">
@@ -181,7 +181,7 @@
     <comment>BetweenX0AndX1 description</comment>
   </data>
   <data name="AtX0" xml:space="preserve">
-    <value>op {0}</value>
+    <value>om {0}</value>
     <comment>AtX0 description</comment>
   </data>
   <data name="ComaEveryDay" xml:space="preserve">

--- a/test/TestFormats.nl.cs
+++ b/test/TestFormats.nl.cs
@@ -1,4 +1,4 @@
-﻿using Xunit;
+using Xunit;
 
 namespace CronExpressionDescriptor.Test
 {
@@ -35,7 +35,7 @@ namespace CronExpressionDescriptor.Test
         [Fact]
         public void TestTimeOfDayCertainDaysOfWeek()
         {
-            Assert.Equal("Op 11:00 PM, maandag t/m vrijdag", GetDescription("0 23 ? * MON-FRI"));
+            Assert.Equal("Om 11:00 PM, maandag t/m vrijdag", GetDescription("0 23 ? * MON-FRI"));
         }
 
         [Fact]
@@ -66,13 +66,13 @@ namespace CronExpressionDescriptor.Test
         [Fact]
         public void TestWeekdaysAtTime()
         {
-            Assert.Equal("Op 11:30 AM, maandag t/m vrijdag", GetDescription("30 11 * * 1-5"));
+            Assert.Equal("Om 11:30 AM, maandag t/m vrijdag", GetDescription("30 11 * * 1-5"));
         }
 
         [Fact]
         public void TestDailyAtTime()
         {
-            Assert.Equal("Op 11:30 AM", GetDescription("30 11 * * *"));
+            Assert.Equal("Om 11:30 AM", GetDescription("30 11 * * *"));
         }
 
         [Fact]
@@ -96,55 +96,55 @@ namespace CronExpressionDescriptor.Test
         [Fact]
         public void TestTwoTimesEachAfternoon()
         {
-            Assert.Equal("Op 02:30 PM en 04:30 PM", GetDescription("30 14,16 * * *"));
+            Assert.Equal("Om 02:30 PM en 04:30 PM", GetDescription("30 14,16 * * *"));
         }
 
         [Fact]
         public void TestThreeTimesDaily()
         {
-            Assert.Equal("Op 06:30 AM, 02:30 PM en 04:30 PM", GetDescription("30 6,14,16 * * *"));
+            Assert.Equal("Om 06:30 AM, 02:30 PM en 04:30 PM", GetDescription("30 6,14,16 * * *"));
         }
 
         [Fact]
         public void TestOnceAWeek()
         {
-            Assert.Equal("Op 09:46 AM, alleen op maandag", GetDescription("46 9 * * 1"));
+            Assert.Equal("Om 09:46 AM, alleen op maandag", GetDescription("46 9 * * 1"));
         }
 
         [Fact]
         public void TestDayOfMonth()
         {
-            Assert.Equal("Op 12:23 PM, op dag 15 van de maand", GetDescription("23 12 15 * *"));
+            Assert.Equal("Om 12:23 PM, op dag 15 van de maand", GetDescription("23 12 15 * *"));
         }
 
         [Fact]
         public void TestMonthName()
         {
-            Assert.Equal("Op 12:23 PM, alleen in januari", GetDescription("23 12 * JAN *"));
+            Assert.Equal("Om 12:23 PM, alleen in januari", GetDescription("23 12 * JAN *"));
         }
 
         [Fact]
         public void TestDayOfMonthWithQuestionMark()
         {
-            Assert.Equal("Op 12:23 PM, alleen in januari", GetDescription("23 12 ? JAN *"));
+            Assert.Equal("Om 12:23 PM, alleen in januari", GetDescription("23 12 ? JAN *"));
         }
 
         [Fact]
         public void TestMonthNameRange2()
         {
-            Assert.Equal("Op 12:23 PM, januari t/m februari", GetDescription("23 12 * JAN-FEB *"));
+            Assert.Equal("Om 12:23 PM, januari t/m februari", GetDescription("23 12 * JAN-FEB *"));
         }
 
         [Fact]
         public void TestMonthNameRange3()
         {
-            Assert.Equal("Op 12:23 PM, januari t/m maart", GetDescription("23 12 * JAN-MAR *"));
+            Assert.Equal("Om 12:23 PM, januari t/m maart", GetDescription("23 12 * JAN-MAR *"));
         }
 
         [Fact]
         public void TestDayOfWeekName()
         {
-            Assert.Equal("Op 12:23 PM, alleen op zondag", GetDescription("23 12 * * SUN"));
+            Assert.Equal("Om 12:23 PM, alleen op zondag", GetDescription("23 12 * * SUN"));
         }
 
         [Fact]
@@ -210,7 +210,7 @@ namespace CronExpressionDescriptor.Test
         [Fact]
         public void TestTimeOfDayWithSeconds()
         {
-            Assert.Equal("Op 02:02:30 PM", GetDescription("30 02 14 * * *"));
+            Assert.Equal("Om 02:02:30 PM", GetDescription("30 02 14 * * *"));
         }
 
         [Fact]
@@ -228,37 +228,37 @@ namespace CronExpressionDescriptor.Test
         [Fact]
         public void TestEvery5MinutesAt30Seconds()
         {
-            Assert.Equal("Op 30 seconden na de minuut, elke 5 minuten", GetDescription("30 */5 * * * *"));
+            Assert.Equal("Om 30 seconden na de minuut, elke 5 minuten", GetDescription("30 */5 * * * *"));
         }
 
         [Fact]
         public void TestMinutesPastTheHourRange()
         {
-            Assert.Equal("Op 30 minuten na het uur, tussen 10:00 AM en 01:59 PM, alleen op woensdag en vrijdag", GetDescription("0 30 10-13 ? * WED,FRI"));
+            Assert.Equal("Om 30 minuten na het uur, tussen 10:00 AM en 01:59 PM, alleen op woensdag en vrijdag", GetDescription("0 30 10-13 ? * WED,FRI"));
         }
 
         [Fact]
         public void TestSecondsPastTheMinuteInterval()
         {
-            Assert.Equal("Op 10 seconden na de minuut, elke 5 minuten", GetDescription("10 0/5 * * * ?"));
+            Assert.Equal("Om 10 seconden na de minuut, elke 5 minuten", GetDescription("10 0/5 * * * ?"));
         }
 
         [Fact]
         public void TestBetweenWithInterval()
         {
-            Assert.Equal("Elke 3 minuten, minuut 2 t/m 59 na het uur, op 01:00 AM, 09:00 AM, en 10:00 PM, tussen dag 11 en 26 van de maand, januari t/m juni", GetDescription("2-59/3 1,9,22 11-26 1-6 ?"));
+            Assert.Equal("Elke 3 minuten, minuut 2 t/m 59 na het uur, om 01:00 AM, 09:00 AM, en 10:00 PM, tussen dag 11 en 26 van de maand, januari t/m juni", GetDescription("2-59/3 1,9,22 11-26 1-6 ?"));
         }
 
         [Fact]
         public void TestRecurringFirstOfMonth()
         {
-            Assert.Equal("Op 06:00 AM", GetDescription("0 0 6 1/1 * ?"));
+            Assert.Equal("Om 06:00 AM", GetDescription("0 0 6 1/1 * ?"));
         }
 
         [Fact]
         public void TestMinutesPastTheHour()
         {
-            Assert.Equal("Op 5 minuten na het uur", GetDescription("0 5 0/1 * * ?"));
+            Assert.Equal("Om 5 minuten na het uur", GetDescription("0 5 0/1 * * ?"));
         }
 
         [Fact]
@@ -282,13 +282,13 @@ namespace CronExpressionDescriptor.Test
         [Fact]
         public void TestYearRange2()
         {
-            Assert.Equal("Op 12:23 PM, januari t/m februari, 2013 t/m 2014", GetDescription("23 12 * JAN-FEB * 2013-2014"));
+            Assert.Equal("Om 12:23 PM, januari t/m februari, 2013 t/m 2014", GetDescription("23 12 * JAN-FEB * 2013-2014"));
         }
 
         [Fact]
         public void TestYearRange3()
         {
-            Assert.Equal("Op 12:23 PM, januari t/m maart, 2013 t/m 2015", GetDescription("23 12 * JAN-MAR * 2013-2015"));
+            Assert.Equal("Om 12:23 PM, januari t/m maart, 2013 t/m 2015", GetDescription("23 12 * JAN-MAR * 2013-2015"));
         }
 
         [Fact]
@@ -300,7 +300,7 @@ namespace CronExpressionDescriptor.Test
         [Fact]
         public void TestDayOfWeekModifier()
         {
-            Assert.Equal("Op 12:23 PM, op de tweede zondag van de maand", GetDescription("23 12 * * SUN#2"));
+            Assert.Equal("Om 12:23 PM, op de tweede zondag van de maand", GetDescription("23 12 * * SUN#2"));
         }
 
         [Fact]
@@ -309,62 +309,62 @@ namespace CronExpressionDescriptor.Test
             Options options = new Options();
             options.DayOfWeekStartIndexZero = false;
 
-            Assert.Equal("Op 12:23 PM, op de tweede zondag van de maand", GetDescription("23 12 * * 1#2", options));
+            Assert.Equal("Om 12:23 PM, op de tweede zondag van de maand", GetDescription("23 12 * * 1#2", options));
         }
 
         [Fact]
         public void TestHourRangeWithEveryPortion()
         {
-            Assert.Equal("Op 25 minuten na het uur, elke 13 uur, tussen 07:00 AM en 07:59 PM", GetDescription("0 25 7-19/13 ? * *"));
+            Assert.Equal("Om 25 minuten na het uur, elke 13 uur, tussen 07:00 AM en 07:59 PM", GetDescription("0 25 7-19/13 ? * *"));
         }
 
         [Fact]
         public void TestHourRangeWithTrailingZeroWithEveryPortion()
         {
-            Assert.Equal("Op 25 minuten na het uur, elke 13 uur, tussen 07:00 AM en 08:59 PM", GetDescription("0 25 7-20/13 ? * *"));
+            Assert.Equal("Om 25 minuten na het uur, elke 13 uur, tussen 07:00 AM en 08:59 PM", GetDescription("0 25 7-20/13 ? * *"));
         }
 
         [Fact]
         public void TestSecondsInternalWithStepValue()
         {
             // GitHub Issue #49: https://github.com/bradymholt/cron-expression-descriptor/issues/49
-            Assert.Equal("Elke 30 seconden, beginnend op 5 seconden na de minuut", GetDescription("5/30 * * * * ?"));
+            Assert.Equal("Elke 30 seconden, beginnend om 5 seconden na de minuut", GetDescription("5/30 * * * * ?"));
         }
 
         [Fact]
         public void TestMinutesInternalWithStepValue()
         {
-            Assert.Equal("Elke 30 minuten, beginnend op 5 minuten na het uur", GetDescription("0 5/30 * * * ?"));
+            Assert.Equal("Elke 30 minuten, beginnend om 5 minuten na het uur", GetDescription("0 5/30 * * * ?"));
         }
 
         [Fact]
         public void TestHoursInternalWithStepValue()
         {
-            Assert.Equal("Elke seconde, elke 8 uur, beginnend op 05:00 AM", GetDescription("* * 5/8 * * ?"));
+            Assert.Equal("Elke seconde, elke 8 uur, beginnend om 05:00 AM", GetDescription("* * 5/8 * * ?"));
         }
 
         [Fact]
         public void TestDayOfMonthInternalWithStepValue()
         {
-            Assert.Equal("Op 07:05 AM, elke 3 dagen, beginnend op dag 2 van de maand", GetDescription("0 5 7 2/3 * ? *"));
+            Assert.Equal("Om 07:05 AM, elke 3 dagen, beginnend op dag 2 van de maand", GetDescription("0 5 7 2/3 * ? *"));
         }
 
         [Fact]
         public void TestMonthInternalWithStepValue()
         {
-            Assert.Equal("Op 07:05 AM, elke 2 maanden, maart t/m december", GetDescription("0 5 7 ? 3/2 ? *"));
+            Assert.Equal("Om 07:05 AM, elke 2 maanden, maart t/m december", GetDescription("0 5 7 ? 3/2 ? *"));
         }
 
         [Fact]
         public void TestDayOfWeekInternalWithStepValue()
         {
-            Assert.Equal("Op 07:05 AM, elke 3 dagen van de week, dinsdag t/m zaterdag", GetDescription("0 5 7 ? * 2/3 *"));
+            Assert.Equal("Om 07:05 AM, elke 3 dagen van de week, dinsdag t/m zaterdag", GetDescription("0 5 7 ? * 2/3 *"));
         }
 
         [Fact]
         public void TestYearInternalWithStepValue()
         {
-            Assert.Equal("Op 07:05 AM, elke 4 jaren, 2016 t/m 9999", GetDescription("0 5 7 ? * ? 2016/4"));
+            Assert.Equal("Om 07:05 AM, elke 4 jaren, 2016 t/m 9999", GetDescription("0 5 7 ? * ? 2016/4"));
         }
     }
 }


### PR DESCRIPTION
At 18:00 PM should be translated to 'Om 18:00 PM', current translation uses 'Op'.

See also: https://www.youtube.com/watch?v=k4AWMUwSFVk&t=158s 