### PR TITLE
Set assembly's neutral language

### DIFF
--- a/lib/CronExpressionDescriptor.csproj
+++ b/lib/CronExpressionDescriptor.csproj
@@ -19,6 +19,7 @@
     <RepositoryUrl>https://github.com/bradymholt/cron-expression-descriptor</RepositoryUrl>
     <PackageTags>cron, schedule, quartz, quartz.net, cron expression</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
+    <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>  
   <ItemGroup>
     <None Include="../icon.png" Pack="true" Visible="false" PackagePath="" />


### PR DESCRIPTION
Hi, I am currently attempting to consume this library in a UWP app, and I've been experiencing issues loading resources from the neutral (English) language.

I discovered that this is a somewhat "well-known" issue (as far as UWP goes), due to the way it translates resx/resources to resw/PRI files. The solution is for the originating assembly to declare its neutral language.

For reference, here is that suggestion on StackOverflow: https://stackoverflow.com/a/60811293/4206279

Also as a point of comparison, Humanizer (which, similar to this library, distributes resources in many languages), has the same assembly attribute set: https://github.com/Humanizr/Humanizer/blob/main/src/Humanizer/Properties/AssemblyInfo.cs

In their case, they use the attribute directly in an AssemblyInfo file. But since we're using .NET Standard/Core here, we can set it in the project file. `NeutralLanguage` translates to the assembly attribute `NeutralResourcesLanguage`.

| ![image](https://github.com/bradymholt/cron-expression-descriptor/assets/7417301/ea48f07b-e2c6-49a0-965f-100702ff5c88) |
| - |

Thank you for your consideration!